### PR TITLE
Add Next.js interactive resume skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Resume
+# Interactive Resume
+
+This project is a simple interactive resume built with Next.js and TypeScript.
+Use the left and right arrow keys to navigate between sections.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the resume.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "interactive-resume",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "@types/react": "latest",
+    "@types/node": "latest"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,8 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import styles from '../styles/Home.module.css';
+
+const sections = [
+  { id: 'about', title: 'About', content: 'This is a demo interactive resume.' },
+  { id: 'skills', title: 'Skills', content: 'TypeScript, React, Next.js, CSS' },
+  { id: 'experience', title: 'Experience', content: '5+ years building web apps' },
+  { id: 'contact', title: 'Contact', content: 'email@example.com' },
+];
+
+export default function Home() {
+  const [position, setPosition] = useState(0);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') setPosition((p) => Math.min(p + 1, sections.length - 1));
+      if (e.key === 'ArrowLeft') setPosition((p) => Math.max(p - 1, 0));
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.character} style={{ left: `${position * 25}%` }}>
+        🚀
+      </div>
+      {sections.map((sec, i) => (
+        <section key={sec.id} className={styles.section} style={{ transform: `translateX(${(i - position) * 100}%)` }}>
+          <h2>{sec.title}</h2>
+          <p>{sec.content}</p>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,0 +1,26 @@
+.container {
+  position: relative;
+  height: 100%;
+  width: 400%;
+  display: flex;
+}
+
+.section {
+  min-width: 100%;
+  height: 100%;
+  padding: 50px;
+  box-sizing: border-box;
+  transition: transform 0.5s;
+}
+
+.section:nth-child(1) { background: #f44336; }
+.section:nth-child(2) { background: #3f51b5; }
+.section:nth-child(3) { background: #4caf50; }
+.section:nth-child(4) { background: #ff9800; }
+
+.character {
+  position: absolute;
+  bottom: 20px;
+  transition: left 0.5s;
+  font-size: 2rem;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,7 @@
+html, body, #__next {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: Arial, sans-serif;
+  overflow: hidden;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js TypeScript project
- add basic interactive resume page
- document project usage

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9bdde1c483328f725681f370e29a